### PR TITLE
Revert "[cmake] export build-tree targets"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -87,10 +87,6 @@ install(EXPORT exchcxx-targets
     ${INSTALL_CONFIGDIR}
 )
 
-# Export build-tree targets also (to be usable by e.g. FetchContent)
-export(EXPORT exchcxx-targets
-    NAMESPACE ExchCXX::
-    FILE "${PROJECT_BINARY_DIR}/ExchCXXTargets.cmake")
 
 #Create a ConfigVersion.cmake file
 include(CMakePackageConfigHelpers)


### PR DESCRIPTION
Reverts wavefunction91/ExchCXX#2

@evaleev We have to hold off on this until I update to the latest Libxc with exported build trees, It breaks CI downstream