### PR TITLE
[STALE] Update Libxc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,21 +36,21 @@ endif()
 
 
 ## Find LibXC
-find_package( Libxc 5.0.0 CONFIG QUIET )
+find_package( Libxc 6.0.0 CONFIG QUIET )
 
 if( ${Libxc_FOUND} )
 
   message( STATUS "Found: Libxc Version ${Libxc_VERSION}" )
-  if( Libxc_VERSION VERSION_GREATER_EQUAL "6.0.0" )
-    message( FATAL_ERROR "Libxc version 6+ breaks the API currently used in ExchCXX" )
-  endif()
+  #if( Libxc_VERSION VERSION_GREATER_EQUAL "6.0.0" )
+  #  message( FATAL_ERROR "Libxc version 6+ breaks the API currently used in ExchCXX" )
+  #endif()
 
 else()
 
   FetchContent_Declare(
     libxc
     GIT_REPOSITORY https://gitlab.com/libxc/libxc.git
-    GIT_TAG        5.0.0
+    GIT_TAG        master 
   )
 
   FetchContent_MakeAvailable( libxc )

--- a/src/libxc.cxx
+++ b/src/libxc.cxx
@@ -110,21 +110,15 @@ bool LibxcKernelImpl::is_lda_() const noexcept {
 }
 
 bool LibxcKernelImpl::is_gga_() const noexcept {
-  return 
-    (kernel_.info->family == XC_FAMILY_GGA    ) or
-    (kernel_.info->family == XC_FAMILY_HYB_GGA);
+  return kernel_.info->family == XC_FAMILY_GGA; 
 }
 
 bool LibxcKernelImpl::is_mgga_() const noexcept {
-  return 
-    (kernel_.info->family == XC_FAMILY_MGGA    ) or
-    (kernel_.info->family == XC_FAMILY_HYB_MGGA);
+  return kernel_.info->family == XC_FAMILY_MGGA;
 }
 
 bool LibxcKernelImpl::is_hyb_() const noexcept {
-  return
-    (kernel_.info->family == XC_FAMILY_HYB_GGA ) or
-    (kernel_.info->family == XC_FAMILY_HYB_MGGA);
+  return kernel_.hyb_number_terms != 0;
 }
 
 bool LibxcKernelImpl::is_polarized_() const noexcept {
@@ -133,7 +127,7 @@ bool LibxcKernelImpl::is_polarized_() const noexcept {
 
 
 double LibxcKernelImpl::hyb_exx_() const noexcept {
-  return xc_hyb_exx_coef( &kernel_ );
+  return is_hyb_() ? xc_hyb_exx_coef( &kernel_ ) : 0.;
 }
 
 bool LibxcKernelImpl::supports_inc_interface_() const noexcept {


### PR DESCRIPTION
~~Code runs but testing fails due to change in polarized GGA strategies upstream in Libxc~~

Bump to Libxc 6 will be handled in #23. This PR contains API changes that will be necessary for Libxc 7+.
