### PR TITLE
misc cmake fixes for libxc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,8 +49,8 @@ else()
 
   FetchContent_Declare(
     libxc
-    GIT_REPOSITORY https://gitlab.com/libxc/libxc.git
-    GIT_TAG        5.0.0
+    GIT_REPOSITORY https://gitlab.com/eduard1/libxc.git
+    GIT_TAG        master
   )
 
   FetchContent_MakeAvailable( libxc )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ else()
   FetchContent_Declare(
     libxc
     GIT_REPOSITORY https://gitlab.com/eduard1/libxc.git
-    GIT_TAG        15337b095f48fc97ce6835192b1675abaf794c93  # v5.0.0 + pr324
+    GIT_TAG        53883f416d0f421e4e856171d72c81fb331d8a57  # v5.0.0 + pr324 + pr351
   )
 
   FetchContent_MakeAvailable( libxc )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,12 @@ else()
       $<BUILD_INTERFACE:${libxc_BINARY_DIR}/gen_funcidx>
   )
 
+  # disable unity builds for libxc
+  if (CMAKE_UNITY_BUILD)
+    set_target_properties(xc PROPERTIES UNITY_BUILD OFF)
+    message(STATUS "Will disable unity-build for Libxc::xc")
+  endif()
+
 endif()
         
 add_subdirectory( src  )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ else()
   FetchContent_Declare(
     libxc
     GIT_REPOSITORY https://gitlab.com/eduard1/libxc.git
-    GIT_TAG        master
+    GIT_TAG        15337b095f48fc97ce6835192b1675abaf794c93  # v5.0.0 + pr324
   )
 
   FetchContent_MakeAvailable( libxc )


### PR DESCRIPTION
this points to my fork of libxc on gitlab which incorporates 2 of its PRs (324 and 351; in master) cherry-picked on top of v5.0.0 ... once exchcxx is ported to libxc 6 you can repoint to libxc master.