### PR TITLE
Test functional_map and kernel_map

### DIFF
--- a/test/ut_common.hpp
+++ b/test/ut_common.hpp
@@ -66,4 +66,27 @@ static constexpr std::array builtin_supported_kernels = {
   ExchCXX::Kernel::PBE0
 };
 
+static constexpr std::array string_kernal_pairs = {
+    std::pair("SlaterExchange", ExchCXX::Kernel::SlaterExchange),
+    std::pair("PBE_X",ExchCXX::Kernel::PBE_X),
+    std::pair("PBE_C", ExchCXX::Kernel::PBE_C),
+    std::pair("LYP", ExchCXX::Kernel::LYP),
+    std::pair("B3LYP", ExchCXX::Kernel::B3LYP),
+    std::pair("PBE0", ExchCXX::Kernel::PBE0),
+    std::pair("VWN3", ExchCXX::Kernel::VWN3),
+    std::pair("VWN5", ExchCXX::Kernel::VWN5),
+    std::pair("PZ81", ExchCXX::Kernel::PZ81),
+    std::pair("PZ81_MOD", ExchCXX::Kernel::PZ81_MOD),
+    std::pair("PW91_LDA", ExchCXX::Kernel::PW91_LDA),
+    std::pair("PW91_LDA_MOD", ExchCXX::Kernel::PW91_LDA_MOD),
+    std::pair("PW91_LDA_RPA", ExchCXX::Kernel::PW91_LDA_RPA),
+    std::pair("B88", ExchCXX::Kernel::B88)
+};
 
+static constexpr std::array string_functional_pairs = {
+    std::pair("SVWN3", ExchCXX::Functional::SVWN3),
+    std::pair("SVWN5", ExchCXX::Functional::SVWN5),
+    std::pair("BLYP", ExchCXX::Functional::BLYP),
+    std::pair("B3LYP", ExchCXX::Functional::B3LYP),
+    std::pair("PBE0", ExchCXX::Functional::PBE0)
+};

--- a/test/xc_functional_test.cxx
+++ b/test/xc_functional_test.cxx
@@ -518,4 +518,22 @@ TEST_CASE( "GGA XC Functionals", "[xc-gga]" ) {
 
 }
 
+TEST_CASE( "functional_map Test", "[xc-functional-map]") {
 
+  SECTION("Conversion of String to Functional") {
+
+    for (auto pair : string_functional_pairs) {
+      CHECK(functional_map.value(pair.first) == pair.second);
+    }
+
+  }
+
+  SECTION("Conversion of Functional to String") {
+
+    for (auto pair : string_functional_pairs) {
+      CHECK(functional_map.key(pair.second) == pair.first);
+    }
+
+  }
+
+}

--- a/test/xc_kernel_test.cxx
+++ b/test/xc_kernel_test.cxx
@@ -559,6 +559,25 @@ TEST_CASE( "Scale and Increment Interface", "[xc-inc]" ) {
   }
 }
 
+TEST_CASE( "kernel_map Test", "[xc-kernel-map]") {
+
+  SECTION("Conversion of String to Kernel") {
+
+    for (auto pair : string_kernal_pairs) {
+      CHECK(kernel_map.value(pair.first) == pair.second);
+    }
+
+  }
+
+  SECTION("Conversion of Kernel to String") {
+
+    for (auto pair : string_kernal_pairs) {
+      CHECK(kernel_map.key(pair.second) == pair.first);
+    }
+
+  }
+
+}
 
 #ifdef EXCHCXX_ENABLE_CUDA
 


### PR DESCRIPTION
Added simple checks that the functional_map takes strings to correct functionals and also reverse. Also, check kernel_map correctly maps strings to kernels and also reverse.